### PR TITLE
Add PIWIK_PROXY_HEADER configuration option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ Piwik Track Settings
  * default: _/piwik/_ - you can chance that to whatever you want/need
 * __PIWIK\_NOT\_BEHIND\_PROXY__
  * default: not set - if set to any value the settings to listen behind a reverse proxy server will be removed
+* __PIWIK_PROXY_HEADER__
+ * default: HTTP_X_FORWARDED_FOR - if set Piwik will attempt to use the given header to determine the original client address.
+   `HTTP_CF_CONNECTING_IP` or `HTTP_CLIENT_IP` may be helpful if behind certain proxies.
 * __PIWIK\_HSTS\_HEADERS\_ENABLE__
  * default: not set - if set to any value the HTTP Strict Transport Security will be activated on SSL Channel
 * __PIWIK\_HSTS\_HEADERS\_ENABLE\_NO\_SUBDOMAINS__

--- a/startup-piwik.sh
+++ b/startup-piwik.sh
@@ -6,6 +6,12 @@ then
   sed -i '4,5d' /piwik/config/config.ini.php
 else
   echo ">> piwik is configured to listen behind a reverse proxy now"
+
+  if [ ! -z ${PIWIK_PROXY_HEADER+x} ]
+  then
+    echo ">> using $PIWIK_PROXY_HEADER header to determine client address"
+    sed -i "s/HTTP_X_FORWARDED_FOR/$PIWIK_PROXY_HEADER/g" /piwik/config/config.ini.php
+  fi
 fi
 
 if [ ! -z ${PIWIK_HSTS_HEADERS_ENABLE+x} ]


### PR DESCRIPTION
Some proxy setups require a different header than `HTTP_X_FORWARDED_FOR` to obtain the correct client IP address. The added option gives that configuration ability to this docker image.

Here is the relevant section from the Piwik user guide:
http://piwik.org/faq/how-to-install/faq_98/
