### PR TITLE
Upgrade piwik to version 2.17.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM marvambass/nginx-ssl-php
 MAINTAINER MarvAmBass
 
 ENV DH_SIZE="2048"
-ENV PIWIK_VERSION="2.16.5"
+ENV PIWIK_VERSION="2.17.1"
 
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get -q -y update && \


### PR DESCRIPTION
I upgraded the dockerfile to the newest version of Piwik.
It would be great if you also can push it as a tag with the version number.
So i can use a fixed version when i start the container.

Thanks!